### PR TITLE
fix(orderForm):order form submit now working

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {


### PR DESCRIPTION
1.  IN orderForm.js, in `menuItemChosen()`, state was not being set using this.state.item, which isn't a property of OrderForm.state object. 
2.  Property should have been set to this.state.order_item.  It was fixed and form is now submitting correctly
