### PR TITLE
fix(authReducer): email address now showing in ./view-orders.

### DIFF
--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
1.  In the `redux/reducers/authReducers`, state for login, parameter for email property not set correctly.
2.  Parameter was updated, and now visible in the ordered_by field.
