### PR TITLE
feat(logout): logout component created, clearing auth info and redirect to `/`

### DIFF
--- a/application/src/components/index.js
+++ b/application/src/components/index.js
@@ -4,5 +4,6 @@ import Nav from './nav/nav';
 import OrderForm from './order-form/orderForm';
 import Template from './common/template';
 import ViewOrders from './view-orders/viewOrders';
+import Logout from './logout/logout';
 
-export { Login, OrderForm, Main, Nav, Template, ViewOrders };
+export { Login, OrderForm, Main, Nav, Template, ViewOrders, Logout };

--- a/application/src/components/logout/logout.js
+++ b/application/src/components/logout/logout.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react';
+import * as actions from '../../redux/actions/authActions';
+import { Redirect } from 'react-router-dom';
+import { connect } from 'react-redux';
+
+class Logout extends Component {
+    componentDidMount () {
+        this.props.onLogout();
+    }
+    render () {
+        return <Redirect to='/' />
+    }
+}
+////  Calling lougoutUser() from ../../redux/actions/authActions' to clear user token, then redirecting route from '/logout' back to '../main' ////
+
+const mapDispatchToProps = dispatch => {
+    return {
+        onLogout: () => dispatch(actions.logoutUser())
+    }
+}
+
+export default connect(null, mapDispatchToProps)(Logout);

--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -42,7 +42,7 @@ class OrderForm extends Component {
             }
         })
         .then(res => res.json())
-        .then(response => console.log("Success", JSON.stringify(response)))
+        .then(res => console.log("Success", JSON.stringify(res)))
         .catch(error => console.error(error));
     }
 

--- a/application/src/router/appRouter.js
+++ b/application/src/router/appRouter.js
@@ -1,16 +1,34 @@
 import React from 'react';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
-import { Main, Login, OrderForm, ViewOrders } from '../components';
+import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { Main, Login, OrderForm, ViewOrders, Logout} from '../components';
+
+//// set props to check state for auth token ////
+const mapStateToProps = state => {
+  return {
+    isAuthenticated: state.auth.token !== null
+  };
+};
 
 const AppRouter = (props) => {
-  return (
+  let routes = (
     <Router>
       <Route path="/" exact component={Main} />
       <Route path="/login" exact component={Login} />
-      <Route path="/order" exact component={OrderForm} />
-      <Route path="/view-orders" exact component={ViewOrders} />
+      <Redirect to='/login'></Redirect>
     </Router>
   );
+  if (props.isAuthenticated) {
+    routes = (
+      <Router>
+        <Route path="/order" exact component={OrderForm} />
+        <Route path="/view-orders" exact component={ViewOrders} /> 
+        <Route path="/logout" exact component={Logout} /> 
+
+      </Router>
+    )
+  };
+  return routes
 }
 
-export default AppRouter;
+export default connect(mapStateToProps, null)(AppRouter);


### PR DESCRIPTION
1.  Logout component dispatches to `logoutUser()` in `/redux/actions/authAuctions/` to clear auth token and email from store.  
2.  Then, user is redirected to the main page.
3.  Also, minor syntax fix in orderForm component - `submitForm()` - response parameters set to `res`